### PR TITLE
Reimplemented commonAncestor() to work when MRCA is ur-virus

### DIFF
--- a/Virus.java
+++ b/Virus.java
@@ -133,15 +133,13 @@ public class Virus {
 		while(lineageA != null || lineageB != null) {
 			if(lineageA != null) {
 				lineageA = lineageA.getParent();
-				if(lineageA != null) {
-					if(!ancestrySet.add(lineageA)) {
-						return lineageA;
-					}
+				if(lineageA != null && !ancestrySet.add(lineageA)) {
+					return lineageA;
 				}
 			}
 			if(lineageB != null) {
 				lineageB = lineageB.getParent();
-				if(!ancestrySet.add(lineageB)) {
+				if(lineageB != null && !ancestrySet.add(lineageB)) {
 					return lineageB;
 				}
 			}

--- a/Virus.java
+++ b/Virus.java
@@ -115,33 +115,38 @@ public class Virus {
 	}
 	
 	public Virus commonAncestor(Virus virusB) {
-				
+		// Algorithm proceeds by recursively visiting parents.
+		// It terminates when either lineage arrives at a node already in the ancestry set,
+		// which must have been already visited by the other lineage and thus represents
+		// a common ancestor.
+		
+		assert(virusB != null);
+		if(virusB == this) {
+			return this;
+		}
+		
 		Virus lineageA = this;
 		Virus lineageB = virusB;
-		Virus commonAnc = null;
-		Set<Virus> ancestry = new HashSet<Virus>();		
-		while (true) {
-			if (!ancestry.add(lineageA)) { 
-				commonAnc = lineageA;
-				break; 
-			}		
-			if (!ancestry.add(lineageB)) { 
-				commonAnc = lineageB;
-				break; 
-			}			
-			if (lineageA.getParent() != null) {		
+		Set<Virus> ancestrySet = new HashSet<>();
+		ancestrySet.add(lineageA);
+		ancestrySet.add(lineageB);
+		while(lineageA != null || lineageB != null) {
+			if(lineageA != null) {
 				lineageA = lineageA.getParent();
+				if(lineageA != null) {
+					if(!ancestrySet.add(lineageA)) {
+						return lineageA;
+					}
+				}
 			}
-			if (lineageB.getParent() != null) {
+			if(lineageB != null) {
 				lineageB = lineageB.getParent();
+				if(!ancestrySet.add(lineageB)) {
+					return lineageB;
+				}
 			}
-			if (lineageA.getParent() == null && lineageB.getParent() == null) {	
-				break;
-			}
-		}	
-		
-		return commonAnc;								// returns null when no common ancestor is present
-		
+		}
+		return null;
 	}
 	
 	public double distance(Virus virusB) {

--- a/VirusTree.java
+++ b/VirusTree.java
@@ -42,8 +42,8 @@ public class VirusTree {
 	// go through tips and find TMRCA
 	public static Virus getTMRCA() {
 		Virus tmrca = tips.get(0);
-		for (Virus v : tips) {	
-			tmrca = tmrca.commonAncestor(v);
+		for(int i = 1; i < tips.size(); i++) {
+			tmrca = tmrca.commonAncestor(tips.get(i));
 		}
 		return tmrca;
 	}


### PR DESCRIPTION
The `commonAncestor()` method of the `Virus` class returned `null` if the MRCA was the ur-virus, since the final if statement would get triggered and break out of the loop before the ancestry set had a chance to get checked. This would trigger a null pointer exception during tree re-rooting if the root of the tree was the ur-virus.